### PR TITLE
[docs] Add docs on logs rich content syntax

### DIFF
--- a/docs/content/internal/modules/logs/event-classifications.md
+++ b/docs/content/internal/modules/logs/event-classifications.md
@@ -4,61 +4,55 @@ title: Event classifications
 
 This document contains a classification of each relevant log event type (defined in the protobuf enum `logs.event.EventType`) based on what their source will be (i.e. how we will get them from Discord).
 
-<Alert type="info">
-
-All of the events that are classified as "Audit log, with special in certain cases" are all classified as such for the same reason, but I forgot what it is. 🙂. Don't worry about it for now.
-
-</Alert>
-
 ###### Classification table
 
-| EventType variant               | Expected source                                                        |
-| ------------------------------- | ---------------------------------------------------------------------- |
-| EventTypeGuildCreate            | Special (this is sourced from guild metadata)                          |
-| EventTypeMemberJoin             | Gateway, with special in certain cases (to source historical events)   |
-| EventTypeMemberLeave            | Gateway                                                                |
-| EventTypeMessageSend            | Gateway, with special in certain cases  (to source historical events)  |
-| EventTypeMessageReply           | Gateway, with special in certain cases  (to source historical events)  |
-| EventTypeMessageEdit            | Gateway                                                                |
-| EventTypeReactionAdd            | Gateway                                                                |
-| EventTypeReactionRemove         | Gateway                                                                |
-| EventTypeReactionBulkRemove     | Gateway                                                                |
-| EventTypeInteractionCreate      | Gateway                                                                |
-| EventTypeMessageDelete          | Hybrid  (gateway to get actual message, audit log to get who deleted)  |
-| EventTypeMessageBulkDelete      | Hybrid  (gateway to get actual messages, audit log to get who deleted) |
-| EventTypeGuildUpdate            | Audit log                                                              |
-| EventTypeChannelCreate          | Audit log, with special in certain cases                               |
-| EventTypeChannelUpdate          | Audit log                                                              |
-| EventTypeChannelDelete          | Audit log                                                              |
-| EventTypeChannelOverwriteCreate | Audit log, with special in certain cases                               |
-| EventTypeChannelOverwriteUpdate | Audit log                                                              |
-| EventTypeChannelOverwriteDelete | Audit log                                                              |
-| EventTypeMemberKick             | Audit log                                                              |
-| EventTypeMemberPrune            | Audit log                                                              |
-| EventTypeMemberBanAdd           | Audit log, with special in certain cases                               |
-| EventTypeMemberBanRemove        | Audit log                                                              |
-| EventTypeMemberUpdate           | Audit log                                                              |
-| EventTypeMemberRoleUpdate       | Audit log                                                              |
-| EventTypeMemberVoiceMove        | Audit log                                                              |
-| EventTypeMemberVoiceKick        | Audit log                                                              |
-| EventTypeBotAdd                 | Audit log                                                              |
-| EventTypeRoleCreate             | Audit log, with special in certain cases                               |
-| EventTypeRoleUpdate             | Audit log                                                              |
-| EventTypeRoleDelete             | Audit log                                                              |
-| EventTypeInviteCreate           | Audit log, with special in certain cases                               |
-| EventTypeInviteUpdate           | Audit log                                                              |
-| EventTypeInviteDelete           | Audit log                                                              |
-| EventTypeWebhookCreate          | Audit log, with special in certain cases                               |
-| EventTypeWebhookUpdate          | Audit log                                                              |
-| EventTypeWebhookDelete          | Audit log                                                              |
-| EventTypeEmojiCreate            | Audit log, with special in certain cases                               |
-| EventTypeEmojiUpdate            | Audit log                                                              |
-| EventTypeEmojiDelete            | Audit log                                                              |
-| EventTypeMessagePin             | Audit log, with special in certain cases                               |
-| EventTypeMessageUnpin           | Audit log                                                              |
-| EventTypeIntegrationCreate      | Audit log, with special in certain cases                               |
-| EventTypeIntegrationUpdate      | Audit log                                                              |
-| EventTypeIntegrationDelete      | Audit log                                                              |
+| EventType variant               | Expected source                                                       |
+| ------------------------------- | --------------------------------------------------------------------- |
+| EventTypeGuildCreate            | Special (this is sourced from guild metadata)                         |
+| EventTypeMemberJoin             | Gateway, with special in certain cases (to source historical events)  |
+| EventTypeMemberLeave            | Gateway                                                               |
+| EventTypeMessageSend            | Gateway, with special in certain cases (to source historical events)  |
+| EventTypeMessageReply           | Gateway, with special in certain cases (to source historical events)  |
+| EventTypeMessageEdit            | Gateway                                                               |
+| EventTypeReactionAdd            | Gateway                                                               |
+| EventTypeReactionRemove         | Gateway                                                               |
+| EventTypeReactionBulkRemove     | Gateway                                                               |
+| EventTypeInteractionCreate      | Gateway                                                               |
+| EventTypeMessageDelete          | Hybrid (gateway to get actual message, audit log to get who deleted)  |
+| EventTypeMessageBulkDelete      | Hybrid (gateway to get actual messages, audit log to get who deleted) |
+| EventTypeGuildUpdate            | Audit log                                                             |
+| EventTypeChannelCreate          | Audit log, with special to source the base creation events            |
+| EventTypeChannelUpdate          | Audit log                                                             |
+| EventTypeChannelDelete          | Audit log                                                             |
+| EventTypeChannelOverwriteCreate | Audit log, with special to source the base creation events            |
+| EventTypeChannelOverwriteUpdate | Audit log                                                             |
+| EventTypeChannelOverwriteDelete | Audit log                                                             |
+| EventTypeMemberKick             | Audit log                                                             |
+| EventTypeMemberPrune            | Audit log                                                             |
+| EventTypeMemberBanAdd           | Audit log, with special to source the base creation events            |
+| EventTypeMemberBanRemove        | Audit log                                                             |
+| EventTypeMemberUpdate           | Audit log                                                             |
+| EventTypeMemberRoleUpdate       | Audit log                                                             |
+| EventTypeMemberVoiceMove        | Audit log                                                             |
+| EventTypeMemberVoiceKick        | Audit log                                                             |
+| EventTypeBotAdd                 | Audit log                                                             |
+| EventTypeRoleCreate             | Audit log, with special to source the base creation events            |
+| EventTypeRoleUpdate             | Audit log                                                             |
+| EventTypeRoleDelete             | Audit log                                                             |
+| EventTypeInviteCreate           | Audit log, with special to source the base creation events            |
+| EventTypeInviteUpdate           | Audit log                                                             |
+| EventTypeInviteDelete           | Audit log                                                             |
+| EventTypeWebhookCreate          | Audit log, with special to source the base creation events            |
+| EventTypeWebhookUpdate          | Audit log                                                             |
+| EventTypeWebhookDelete          | Audit log                                                             |
+| EventTypeEmojiCreate            | Audit log, with special to source the base creation events            |
+| EventTypeEmojiUpdate            | Audit log                                                             |
+| EventTypeEmojiDelete            | Audit log                                                             |
+| EventTypeMessagePin             | Audit log, with special to source the base creation events            |
+| EventTypeMessageUnpin           | Audit log                                                             |
+| EventTypeIntegrationCreate      | Audit log, with special to source the base creation events            |
+| EventTypeIntegrationUpdate      | Audit log                                                             |
+| EventTypeIntegrationDelete      | Audit log                                                             |
 
 ### Remaining classifications
 

--- a/docs/content/internal/modules/logs/rich-content.md
+++ b/docs/content/internal/modules/logs/rich-content.md
@@ -22,16 +22,26 @@ The rich content for log entries supports the following Markdown features (basic
 - Inline spoilers: `||spoilers||` => <InlineSpoilerMockup>spoilers</InlineSpoilerMockup>
   - Note: spoilers are not displayed with the same interactivity as in the Discord client; they are just visually marked with a darker background and an icon.
 
-
 <Alert type="warning">
 
 While we try to keep the same behavior as the Discord Markdown renderer embedded in the Discord client, it might vary in some edge cases.
 
 </Alert>
 
+### Inline links
+
+Like with Discord, the logs rich content language also supports auto-linking of URLs into link elements:
+- `https://docs.archit.us/` => <a href="https://docs.archit.us/" rel="noopener" target="_blank">https://docs.archit.us/</a>
+
+<Alert type="info">
+
+Each link embedded in a log event's rich content **must** have each of its URL stems in the `content_metadata.url_stems` field on the `logs.event.Event` protobuf message. For example, the above example would have `["docs.archit.us", "archit.us"]` as the value of its `content_metadata.url_stems` field.
+
+</Alert>
+
 ## Mentions
 
-### User Mention
+### User mention
 
 To mention a user, use their ID as a decimal number:
 
@@ -43,13 +53,19 @@ userMention
 
 Once revision tracking is implemented, this will result in a display on the frontend that includes the users's nickname/name (similar to Discord).
 
+<Alert type="info">
+
+Each user mentioned in a log event's rich content **must** have its ID in the `content_metadata.users_mentioned` field on the `logs.event.Event` protobuf message.
+
+</Alert>
+
 ##### Example
 
 ```
 <@448546825532866560>
 ```
 
-### Role Mention
+### Role mention
 
 To mention a role, use their ID as a decimal number:
 
@@ -61,13 +77,19 @@ roleMention
 
 Once revision tracking is implemented, this will result in a display on the frontend that includes the role's name and color (similar to Discord).
 
+<Alert type="info">
+
+Each role mentioned in a log event's rich content **must** have its ID in the `content_metadata.roles_mentioned` field on the `logs.event.Event` protobuf message.
+
+</Alert>
+
 ##### Example
 
 ```
 <@&607639217840848910>
 ```
 
-### Channel Mention
+### Channel mention
 
 To mention a role, use the channel ID as a decimal number:
 
@@ -79,15 +101,21 @@ channelMention
 
 Once revision tracking is implemented, this will result in a display on the frontend that includes the channel's name (similar to Discord).
 
+<Alert type="info">
+
+Each channel mentioned in a log event's rich content **must** have its ID in the `content_metadata.channels_mentioned` field on the `logs.event.Event` protobuf message.
+
+</Alert>
+
 ##### Example
 
 ```
 <#641064458843586562>
 ```
 
-### Emoji Mention
+### (Custom) emoji mention
 
-To mention (embed) an emoji, at the very minimum the emoji ID is needed. Additionally, if the name is known, it should be included; otherwise, the frontend can't display the actual name in the tooltip (since revision tracking is not performed on emojis).
+To mention (embed) a custom emoji (one uploaded to Discord), at the very minimum the emoji ID is needed. Additionally, if the name is known, it should be included; otherwise, the frontend can't display the actual name in the tooltip (since revision tracking is not performed on emojis).
 
 The leading "a" inside the angle brackets is used to mark the emoji as **animated** (excluding it embeds a normal, non-animated emoji).
 
@@ -96,6 +124,12 @@ emojiMention
   : '<' ( 'a' )? ':' SNOWFLAKE_ID_DECIMAL ':' EMOJI_NAME '>'
   ;
 ```
+
+<Alert type="info">
+
+Each custom emoji used in a log event's rich content **must** have its ID in the `content_metadata.custom_emojis_used` field on the `logs.event.Event` protobuf message. Additionally, if the emoji name is available, it **must** also be included in the `content_metadata.custom_emoji_names_used` field.
+
+</Alert>
 
 ##### Animated emoji example (with name)
 
@@ -121,7 +155,19 @@ emojiMention
 <::792017989583110154>
 ```
 
-### Color Mention
+<Alert type="info">
+
+To assist with full-text search, please also include the emoji name in plaintext where relevant if a log event is specifically about an emoji (and users searching by the name would expect to see it appear).
+
+##### Example
+
+```
+<:architus:792017989583110154> :architus:
+```
+
+</Alert>
+
+### Color mention
 
 To mention (embed) a color, it needs to be formatted as a 6-digit hex color code (using either uppercase or lowercase digits):
 
@@ -146,3 +192,31 @@ HEX_DIGIT
 <##008933>
 <##97154d>
 ```
+
+### Unicode emoji mention
+
+To mention (embed) a unicode emoji, no special syntax is needed: simply include the unicode character within the textual content and it will be converted into an embed (with tooltip) in the web app.
+
+<Alert type="info">
+
+Each unicode emoji used in a log event's rich content **must** have each of its shortcodes in the `content_metadata.emojis_used` field on the `logs.event.Event` protobuf message. For example, the above example would have `["thinking", "thinking_face"]` as the value of its `content_metadata.emojis_used` field.
+
+</Alert>
+
+##### Examples
+
+```
+🤔
+```
+
+<Alert type="info">
+
+To assist with full-text search, please also include the emoji shortcode(s) where relevant if a log event is specifically about an emoji (and users searching by the shortcode(s) would expect to see it appear).
+
+##### Example
+
+```
+🤔 :thinking: :thinking_face:
+```
+
+</Alert>

--- a/docs/content/internal/modules/logs/rich-content.md
+++ b/docs/content/internal/modules/logs/rich-content.md
@@ -1,0 +1,148 @@
+---
+title: Rich content
+badge: in-progress
+---
+
+The primary representation of logs in the web app will be a rich, searchable textual display that supports a subset of Discord Markdown in addition to "mention" inline elements. This page attempts to specify the language's features.
+
+<Alert type="info">
+
+This page specifically describes our own special language for rich formatting in logs. It is not intended to be used by end users, and it won't work in other contexts (i.e. in Discord).
+
+</Alert>
+
+## Markdown
+
+The rich content for log entries supports the following Markdown features (basically all of the inline-level features in Discord Markdown, minus in-line code fragments):
+
+- Inline bolding: `**bold**` => <b>italic</b>
+- Inline italics (both syntaxes): `*italic*` => <i>italic</i>, `_italic_` => <i>italic</i>
+- Inline underline: `__underline__` => <u>underline</u>
+- Inline strikethrough: `~~strikethrough~~` => <strike>strikethrough</strike>
+- Inline spoilers: `||spoilers||` => <InlineSpoilerMockup>spoilers</InlineSpoilerMockup>
+  - Note: spoilers are not displayed with the same interactivity as in the Discord client; they are just visually marked with a darker background and an icon.
+
+
+<Alert type="warning">
+
+While we try to keep the same behavior as the Discord Markdown renderer embedded in the Discord client, it might vary in some edge cases.
+
+</Alert>
+
+## Mentions
+
+### User Mention
+
+To mention a user, use their ID as a decimal number:
+
+```grammar
+userMention
+  : '<@' SNOWFLAKE_ID_DECIMAL '>'
+  ;
+```
+
+Once revision tracking is implemented, this will result in a display on the frontend that includes the users's nickname/name (similar to Discord).
+
+##### Example
+
+```
+<@448546825532866560>
+```
+
+### Role Mention
+
+To mention a role, use their ID as a decimal number:
+
+```grammar
+roleMention
+  : '<@&' SNOWFLAKE_ID_DECIMAL '>'
+  ;
+```
+
+Once revision tracking is implemented, this will result in a display on the frontend that includes the role's name and color (similar to Discord).
+
+##### Example
+
+```
+<@&607639217840848910>
+```
+
+### Channel Mention
+
+To mention a role, use the channel ID as a decimal number:
+
+```grammar
+channelMention
+  : '<#' SNOWFLAKE_ID_DECIMAL '>'
+  ;
+```
+
+Once revision tracking is implemented, this will result in a display on the frontend that includes the channel's name (similar to Discord).
+
+##### Example
+
+```
+<#641064458843586562>
+```
+
+### Emoji Mention
+
+To mention (embed) an emoji, at the very minimum the emoji ID is needed. Additionally, if the name is known, it should be included; otherwise, the frontend can't display the actual name in the tooltip (since revision tracking is not performed on emojis).
+
+The leading "a" inside the angle brackets is used to mark the emoji as **animated** (excluding it embeds a normal, non-animated emoji).
+
+```grammar
+emojiMention
+  : '<' ( 'a' )? ':' SNOWFLAKE_ID_DECIMAL ':' EMOJI_NAME '>'
+  ;
+```
+
+##### Animated emoji example (with name)
+
+```
+<a:catKiss:814220915033899059>
+```
+
+##### Animated emoji example (without name)
+
+```
+<a::814220915033899059>
+```
+
+##### Standard emoji example (with name)
+
+```
+<:architus:792017989583110154>
+```
+
+##### Standard emoji example (without name)
+
+```
+<::792017989583110154>
+```
+
+### Color Mention
+
+To mention (embed) a color, it needs to be formatted as a 6-digit hex color code (using either uppercase or lowercase digits):
+
+```grammar
+colorMention
+  : '<##' hexColor '>'
+  ;
+
+hexColor
+  : HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+  ;
+
+HEX_DIGIT
+  : 'a'..'f' | 'A'..'F' | '0'..'9'
+  ;
+```
+
+##### Examples
+
+```
+<##F97448>
+<##008933>
+<##97154d>
+```

--- a/docs/src/components/HorizontalRule.tsx
+++ b/docs/src/components/HorizontalRule.tsx
@@ -1,0 +1,19 @@
+import { styled } from "linaria/react";
+import React from "react";
+
+import { color } from "@architus/facade/theme/color";
+
+export type HorizontalRuleProps = React.ComponentProps<typeof HorizontalRule>;
+
+/**
+ * Displays a styled variant of `<hr>`
+ */
+const HorizontalRule = styled.hr`
+  border: none;
+  border-top: 2px solid ${color("textLight")};
+  --padding: 2.5rem;
+  margin-top: var(--padding);
+  margin-bottom: var(--padding);
+`;
+
+export default HorizontalRule;

--- a/docs/src/components/InlineSpoilerMockup.tsx
+++ b/docs/src/components/InlineSpoilerMockup.tsx
@@ -1,0 +1,42 @@
+import { styled } from "linaria/react";
+import React from "react";
+import { FaEyeSlash } from "react-icons/fa";
+
+import { color } from "@architus/facade/theme/color";
+
+const Styled = {
+  SpoilerMockup: styled.span`
+    display: inline;
+    background-color: ${color("bg-10")};
+    border-radius: 2;
+    padding: 4px 8px;
+  `,
+  SpoilerIcon: styled(FaEyeSlash)`
+    margin-right: 4px;
+    opacity: 0.5;
+    transform: translateY(3px);
+  `,
+};
+
+export type CompositeBrandProps = {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+/**
+ * Simple, non-functional "spoiler" component that is a mockup
+ * of what will be shown in the logs dashboard
+ */
+export default function InlineSpoilerMarkup({
+  children,
+  className,
+  style,
+}: CompositeBrandProps): React.ReactElement {
+  return (
+    <Styled.SpoilerMockup className={className} style={style}>
+      <Styled.SpoilerIcon />
+      {children}
+    </Styled.SpoilerMockup>
+  );
+}

--- a/docs/src/components/InlineSpoilerMockup.tsx
+++ b/docs/src/components/InlineSpoilerMockup.tsx
@@ -8,7 +8,7 @@ const Styled = {
   SpoilerMockup: styled.span`
     display: inline;
     background-color: ${color("bg-10")};
-    border-radius: 2;
+    border-radius: 4px;
     padding: 4px 8px;
   `,
   SpoilerIcon: styled(FaEyeSlash)`

--- a/docs/src/components/Mdx.tsx
+++ b/docs/src/components/Mdx.tsx
@@ -17,6 +17,7 @@ import Collapse from "@docs/components/Collapse";
 import Demo from "@docs/components/Demo";
 import ExternalSnippet from "@docs/components/ExternalSnippet";
 import { createHeading } from "@docs/components/Heading";
+import HorizontalRule from "@docs/components/HorizontalRule";
 import Iframe from "@docs/components/Iframe";
 import InlineSpoilerMockup from "@docs/components/InlineSpoilerMockup";
 import Overview from "@docs/components/Overview";
@@ -98,6 +99,7 @@ export const overrides = {
   h4: createHeading({ component: "h4" }),
   h5: createHeading({ component: "h5" }),
   h6: createHeading({ component: "h6", right: true }),
+  hr: HorizontalRule,
 } as const;
 
 /**

--- a/docs/src/components/Mdx.tsx
+++ b/docs/src/components/Mdx.tsx
@@ -18,6 +18,7 @@ import Demo from "@docs/components/Demo";
 import ExternalSnippet from "@docs/components/ExternalSnippet";
 import { createHeading } from "@docs/components/Heading";
 import Iframe from "@docs/components/Iframe";
+import InlineSpoilerMockup from "@docs/components/InlineSpoilerMockup";
 import Overview from "@docs/components/Overview";
 import RestRoute from "@docs/components/RestRoute";
 import Table from "@docs/components/Table";
@@ -63,6 +64,7 @@ export const shortcodes = {
     </Alert>
   ),
   ExternalSnippet,
+  InlineSpoilerMockup,
 } as const;
 
 // React components that replace HTML components in the markdown


### PR DESCRIPTION
### Summary

This PR adds docs contents for the logs rich content syntax, including Discord-native embeds in addition to our own custom ones.

It also introduces a couple new components that can be used in Markdown (MDX) content:

- `<hr>` (renders as `<HorizontalRule>`)
- `<InlineSpoilerMockup>`

Finally, this PR includes a minor fix to the logs event classification page.
